### PR TITLE
Adds new drugs to drug spawns, Adds f13 foods to food spawns

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -531,7 +531,9 @@
 				/obj/item/reagent_containers/pill/patch/turbo,
 				/obj/item/reagent_containers/pill/patch/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
-				/obj/item/reagent_containers/syringe/medx
+				/obj/item/reagent_containers/syringe/medx,
+				/obj/item/reagent_containers/hypospray/medipen/rebound,
+				/obj/item/reagent_containers/hypospray/medipen/hydra
 				)
 /* ------------------------------------------------
    --------------WEAPON SPAWNERS-------------------
@@ -1139,17 +1141,17 @@
 	fan_out_items = TRUE
 
 	loot = list(
-				/obj/item/storage/box/ingredients/american,
+				/*/obj/item/storage/box/ingredients/american,
 				/obj/item/storage/box/ingredients/carnivore,
 				/obj/item/storage/box/ingredients/delights,
 				/obj/item/storage/box/ingredients/exotic,
-				/obj/item/storage/box/ingredients/fiesta,
+				/obj/item/storage/box/ingredients/fiesta,*/
 				/obj/item/storage/box/ingredients/fruity,
 				/obj/item/storage/box/ingredients/grains,
-				/obj/item/storage/box/ingredients/italian,
+				/*/obj/item/storage/box/ingredients/italian,
 				/obj/item/storage/box/ingredients/sweets,
 				/obj/item/storage/box/ingredients/vegetarian,
-				/obj/item/storage/box/ingredients/wildcard,
+				/obj/item/storage/box/ingredients/wildcard,*/
 				/obj/item/storage/box/donkpockets,
 				/obj/item/reagent_containers/food/condiment/flour,
 				/obj/item/reagent_containers/food/condiment/rice,
@@ -1161,7 +1163,7 @@
 				/obj/item/reagent_containers/food/condiment/mayonnaise,
 				/obj/item/reagent_containers/food/condiment/soysauce,
 				/obj/item/reagent_containers/food/snacks/beans,
-				/obj/item/reagent_containers/food/snacks/baguette,
+				/*/obj/item/reagent_containers/food/snacks/baguette,
 				/obj/item/reagent_containers/food/snacks/bun,
 				/obj/item/reagent_containers/food/snacks/butter,
 				/obj/item/reagent_containers/food/snacks/cheesewedge,
@@ -1169,19 +1171,35 @@
 				/obj/item/reagent_containers/food/snacks/chocolatebar,
 				/obj/item/reagent_containers/food/snacks/cracker,
 				/obj/item/reagent_containers/food/snacks/icecream,
-				/obj/item/reagent_containers/food/snacks/lollipop,
+				/obj/item/reagent_containers/food/snacks/lollipop,*/
 				/obj/item/reagent_containers/food/snacks/meat/rawbacon,
 				/obj/item/reagent_containers/food/snacks/meat/slab/human,
 				/obj/item/reagent_containers/food/snacks/meat/slab/pug,
 				/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-				/obj/item/reagent_containers/food/snacks/muffin/berry,
+				/*/obj/item/reagent_containers/food/snacks/muffin/berry,
 				/obj/item/reagent_containers/food/snacks/muffin,
 				/obj/item/reagent_containers/food/snacks/no_raisin,
 				/obj/item/reagent_containers/food/snacks/popcorn,
 				/obj/item/reagent_containers/food/snacks/raisincookie,
-				/obj/item/reagent_containers/food/snacks/sosjerky,
+				/obj/item/reagent_containers/food/snacks/sosjerky,*/
 				/obj/item/reagent_containers/food/snacks/sausage,
 				/obj/item/reagent_containers/food/snacks/store/cheesewheel,
+				/obj/item/reagent_containers/food/snacks/f13/crispysquirrel,
+				/obj/item/reagent_containers/food/snacks/f13/squirrelstick,
+				/obj/item/reagent_containers/food/snacks/f13/porknbeans,
+				/obj/item/reagent_containers/food/snacks/f13/instamash,
+				/obj/item/reagent_containers/food/snacks/f13/blamco/large,
+				/obj/item/reagent_containers/food/snacks/f13/blamco,
+				/obj/item/reagent_containers/food/snacks/f13/dandyapples,
+				/obj/item/reagent_containers/food/snacks/f13/steak,
+				/obj/item/reagent_containers/food/snacks/f13/crisps,
+				/obj/item/reagent_containers/food/snacks/f13/sugarbombs,
+				/obj/item/reagent_containers/food/snacks/f13/fancylads,
+				/obj/item/reagent_containers/food/snacks/f13/yumyum,
+				/obj/item/reagent_containers/food/snacks/f13/cram/large,
+				/obj/item/reagent_containers/food/snacks/f13/cram,
+				/obj/item/reagent_containers/food/snacks/f13/bubblegum/large,
+				/obj/item/reagent_containers/food/snacks/f13/bubblegum,
 				"" // a chance to spawn nothing
 				)
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -533,7 +533,9 @@
 				/obj/item/reagent_containers/pill/stimulant,
 				/obj/item/reagent_containers/syringe/medx,
 				/obj/item/reagent_containers/hypospray/medipen/rebound,
-				/obj/item/reagent_containers/hypospray/medipen/hydra
+				/obj/item/reagent_containers/hypospray/medipen/hydra,
+				/obj/item/reagent_containers/pill/patch/addictol,
+				/obj/item/reagent_containers/pill/patch/steady
 				)
 /* ------------------------------------------------
    --------------WEAPON SPAWNERS-------------------


### PR DESCRIPTION
EZ

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the new drugs Swigs made to the drug loot spawns.
Adds f13 foods to food spawns, and removes the food boxes and other such items that made no sense.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Muh immersion. + no more infinite filling boxes of rad-free food lying around everywhere. Eat your Blam-Co, boys and girls. + New drugs to find
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it on a private server. Works great, no food boxes spawning, and the f13 food spawns properly as well. Also saw rebound in a drug spawn spot. (It's new, bros.)
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
