### PR TITLE
Changes Recruit EXP times

### DIFF
--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -182,7 +182,7 @@ Prospector
 	spawn_positions = 1
 	supervisors = "the sheriff and the mayor"
 	selection_color = "#dcba97"
-	exp_requirements = 180
+	exp_requirements = 120
 	exp_type = EXP_TYPE_DEN
 
 	outfit = /datum/outfit/job/den/f13prospector

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -375,7 +375,7 @@ Prime
 	spawn_positions = 8
 	description = "You answer directly to the Prime Decanus and the Centurion, but are expected to follow orders from the Veteran Decanus as needed. You act as a loyal soldier within the Centuria, you have the great honour of serving under Caesar in his quest to unite the scattered tribes of The Mojave."
 	supervisors = "Prime Decanus and up."
-	exp_requirements = 300
+	exp_requirements = 330
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13primelegion
 
@@ -412,7 +412,7 @@ Legionary
 	spawn_positions = 12
 	description = "You answer directly to the Recruit Decanus and the Centurion, but are expected to follow orders from the Prime and Veteran Decanii as needed. You act as a loyal soldier within the Centuria, you have the great honour of serving under Caesar in his quest to unite the scattered tribes of The Mojave."
 	supervisors = "Recruit Decanus and up."
-	exp_requirements = 300
+	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -307,7 +307,7 @@ Trooper
 	description =  "You answer to the Sergeants or Corporals,  following the chain of command, to your commanding officer, the Captain."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
-	exp_requirements = 300
+	exp_requirements = 330
 
 	outfit = /datum/outfit/job/ncr/f13trooper
 
@@ -344,7 +344,7 @@ Recruit
 	description = "You answer to the Sergeants or Corporals,  following the chain of command, to your commanding officer, the Captain."
 	supervisors = "Corporals and above"
 	selection_color = "#fff5cc"
-	exp_requirements = 300
+	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/ncr/f13recruit


### PR DESCRIPTION

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The recruit EXP timers are now 3 hours instead of five. The next rank up has gotten an extra half hour in return. Also changed prospector's EXP time.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was playing the other day and someone said he was waiting for 5 hours (about 2 or 3 entire rounds) just to unlock recruit roles.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I had to use a calculator to calculate minutes to hours... Horrific.
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
tweak: Changed EXP timers for NCR Recruit and Recruit Legionnaire 
/:cl:
